### PR TITLE
Feat/cd customizing

### DIFF
--- a/common/src/main/java/com/example/common/error/code/PropErrorCode.java
+++ b/common/src/main/java/com/example/common/error/code/PropErrorCode.java
@@ -1,0 +1,23 @@
+package com.example.common.error.code;
+
+import org.springframework.http.HttpStatus;
+
+public enum PropErrorCode implements ErrorCode {
+
+    PROP_NOT_FOUND(HttpStatus.NOT_FOUND, "PROP-404", "해당 장식을 찾을 수 없습니다."),
+    PROP_R2_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "PROP-500", "R2 서버 오류입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    PropErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override public HttpStatus status() { return status; }
+    @Override public String code() { return code; }
+    @Override public String message() { return message; }
+}

--- a/common/src/main/java/com/example/common/error/exception/PropException.java
+++ b/common/src/main/java/com/example/common/error/exception/PropException.java
@@ -2,12 +2,12 @@ package com.example.common.error.exception;
 
 import com.example.common.error.code.ErrorCode;
 
-public class R2Exception extends DomainException {
-    public R2Exception(String message, ErrorCode code) {
+public class PropException extends DomainException {
+    public PropException(String message, ErrorCode code) {
         super(message, code);
     }
 
-    public R2Exception(ErrorCode code) {
+    public PropException(ErrorCode code) {
         super(code);
     }
 }

--- a/main-server/src/main/java/com/example/demo/domain/cd/controller/CdController.java
+++ b/main-server/src/main/java/com/example/demo/domain/cd/controller/CdController.java
@@ -1,15 +1,23 @@
 package com.example.demo.domain.cd.controller;
 
-import com.example.common.error.code.CommonErrorCode;
+import com.example.demo.domain.cd.dto.response.CdResponse;
+import com.example.demo.domain.cd.service.CdService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/cd")
+@RequiredArgsConstructor
 public class CdController {
 
-//    @GetMapping("/test-not-found")
-//    public String testNotFound() {
-//        // 일부러 예외 발생
-//        throw new CommonErrorCode();
-//    }
+    private final CdService cdService;
+
+    @GetMapping("/{playlistId}")
+    public ResponseEntity<CdResponse> getSingleCd (@PathVariable("playlistId") Long playListId) {
+        return ResponseEntity.ok().body(cdService.getCdByPlayListId(playListId));
+    }
 }

--- a/main-server/src/main/java/com/example/demo/domain/cd/controller/CdController.java
+++ b/main-server/src/main/java/com/example/demo/domain/cd/controller/CdController.java
@@ -38,7 +38,7 @@ public class CdController {
         return ResponseEntity.ok().body(cdService.getCdByPlaylistId(playListId));
     }
 
-    @GetMapping("/list")
+    @PostMapping("/list")
     @Operation(
             summary = "CD 리스트 조회",
             description = "요청한 CD들 (다중) 을 조회합니다",

--- a/main-server/src/main/java/com/example/demo/domain/cd/controller/CdController.java
+++ b/main-server/src/main/java/com/example/demo/domain/cd/controller/CdController.java
@@ -1,5 +1,7 @@
 package com.example.demo.domain.cd.controller;
 
+import com.example.demo.domain.cd.dto.request.GetCdListRequestDto;
+import com.example.demo.domain.cd.dto.response.CdListResponseDto;
 import com.example.demo.domain.cd.dto.response.CdResponse;
 import com.example.demo.domain.cd.service.CdService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,10 +10,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/cd")
@@ -34,6 +35,24 @@ public class CdController {
             }
     )
     public ResponseEntity<CdResponse> getSingleCd (@PathVariable("playlistId") Long playListId) {
-        return ResponseEntity.ok().body(cdService.getCdByPlayListId(playListId));
+        return ResponseEntity.ok().body(cdService.getCdByPlaylistId(playListId));
+    }
+
+    @GetMapping("/list")
+    @Operation(
+            summary = "CD 리스트 조회",
+            description = "요청한 CD들 (다중) 을 조회합니다",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            content = @Content(
+                                    schema = @Schema(implementation = CdListResponseDto.class)
+                            )
+                    )
+            }
+    )
+    public ResponseEntity<CdListResponseDto> getCdList (@RequestBody GetCdListRequestDto getCdListRequestDto) {
+        List<Long> playListIdList = getCdListRequestDto.playlistIds();
+        return ResponseEntity.ok().body(cdService.getAllCdByPlaylistIdList(playListIdList));
     }
 }

--- a/main-server/src/main/java/com/example/demo/domain/cd/controller/CdController.java
+++ b/main-server/src/main/java/com/example/demo/domain/cd/controller/CdController.java
@@ -2,6 +2,10 @@ package com.example.demo.domain.cd.controller;
 
 import com.example.demo.domain.cd.dto.response.CdResponse;
 import com.example.demo.domain.cd.service.CdService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +21,18 @@ public class CdController {
     private final CdService cdService;
 
     @GetMapping("/{playlistId}")
+    @Operation(
+            summary = "CD 조회",
+            description = "요청한 CD (단일) 를 조회합니다",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            content = @Content(
+                                    schema = @Schema(implementation = CdResponse.class)
+                            )
+                    )
+            }
+    )
     public ResponseEntity<CdResponse> getSingleCd (@PathVariable("playlistId") Long playListId) {
         return ResponseEntity.ok().body(cdService.getCdByPlayListId(playListId));
     }

--- a/main-server/src/main/java/com/example/demo/domain/cd/dto/request/GetCdListRequestDto.java
+++ b/main-server/src/main/java/com/example/demo/domain/cd/dto/request/GetCdListRequestDto.java
@@ -1,0 +1,6 @@
+package com.example.demo.domain.cd.dto.request;
+
+import java.util.List;
+
+public record GetCdListRequestDto(List<Long> playlistIds) {
+}

--- a/main-server/src/main/java/com/example/demo/domain/cd/dto/response/CdItemResponse.java
+++ b/main-server/src/main/java/com/example/demo/domain/cd/dto/response/CdItemResponse.java
@@ -1,0 +1,9 @@
+package com.example.demo.domain.cd.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record CdItemResponse(Long cdItemId, Long propId,
+                             Long xCoordinate, Long yCoordinate, Long zCoordinate, Long angle,
+                             String imageUrl) {
+}

--- a/main-server/src/main/java/com/example/demo/domain/cd/dto/response/CdListResponseDto.java
+++ b/main-server/src/main/java/com/example/demo/domain/cd/dto/response/CdListResponseDto.java
@@ -1,0 +1,6 @@
+package com.example.demo.domain.cd.dto.response;
+
+import java.util.List;
+
+public record CdListResponseDto(List<CdResponse> cds) {
+}

--- a/main-server/src/main/java/com/example/demo/domain/cd/dto/response/CdResponse.java
+++ b/main-server/src/main/java/com/example/demo/domain/cd/dto/response/CdResponse.java
@@ -5,5 +5,5 @@ import lombok.Builder;
 import java.util.List;
 
 @Builder
-public record CdResponse(Long playListId, List<CdItemResponse> cdItems) {
+public record CdResponse(Long playlistId, List<CdItemResponse> cdItems) {
 }

--- a/main-server/src/main/java/com/example/demo/domain/cd/dto/response/CdResponse.java
+++ b/main-server/src/main/java/com/example/demo/domain/cd/dto/response/CdResponse.java
@@ -1,0 +1,9 @@
+package com.example.demo.domain.cd.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record CdResponse(Long playListId, List<CdItemResponse> cdItems) {
+}

--- a/main-server/src/main/java/com/example/demo/domain/cd/entity/Cd.java
+++ b/main-server/src/main/java/com/example/demo/domain/cd/entity/Cd.java
@@ -25,6 +25,9 @@ public class Cd {
     @Column(name = "y_coordinate")
     private Long yCoordinate;
 
+    @Column(name = "z_coordinate")
+    private Long zCoordinate;
+
     @Column(name = "angle")
     private Long angle;
 

--- a/main-server/src/main/java/com/example/demo/domain/cd/repository/CdRepository.java
+++ b/main-server/src/main/java/com/example/demo/domain/cd/repository/CdRepository.java
@@ -12,6 +12,7 @@ public interface CdRepository extends JpaRepository<Cd, Long> {
     @Query("""
         select
           c.id as cdId,
+          c.playlist.id as playlistId,
           p.id as propId,
           c.xCoordinate as xCoordinate,
           c.yCoordinate as yCoordinate,
@@ -22,5 +23,22 @@ public interface CdRepository extends JpaRepository<Cd, Long> {
           join c.prop p
         where c.playlist.id = :playlistId
     """)
-    List<CdItemView> findAllWithImageKeys(Long playlistId);
+    List<CdItemView> findAllByPlaylistWithImageKeys(Long playlistId);
+
+    @Query("""
+       select
+        c.id as cdId,
+        c.playlist.id as playlistId,
+        p.id as propId,
+        c.xCoordinate as xCoordinate,
+        c.yCoordinate as yCoordinate,
+        c.zCoordinate as zCoordinate,
+        c.angle as angle,
+        p.imageKey as imageKey
+       from Cd c
+        join c.prop p
+       where c.playlist.id in :playlistIdList
+    order by c.playlist.id asc, c.zCoordinate asc, c.id asc
+    """)
+    List<CdItemView> findAllByPlaylistIdWithImageKeysIn(@Param("playlistIdList") List<Long> playlistIdList);
 }

--- a/main-server/src/main/java/com/example/demo/domain/cd/repository/CdRepository.java
+++ b/main-server/src/main/java/com/example/demo/domain/cd/repository/CdRepository.java
@@ -1,0 +1,26 @@
+package com.example.demo.domain.cd.repository;
+
+import com.example.demo.domain.cd.entity.Cd;
+import com.example.demo.domain.cd.repository.projection.CdItemView;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface CdRepository extends JpaRepository<Cd, Long> {
+    @Query("""
+        select
+          c.id as cdId,
+          p.id as propId,
+          c.xCoordinate as xCoordinate,
+          c.yCoordinate as yCoordinate,
+          c.zCoordinate as zCoordinate,
+          c.angle as angle,
+          p.imageKey as imageKey
+        from Cd c
+          join c.prop p
+        where c.playlist.id = :playlistId
+    """)
+    List<CdItemView> findAllWithImageKeys(Long playlistId);
+}

--- a/main-server/src/main/java/com/example/demo/domain/cd/repository/projection/CdItemView.java
+++ b/main-server/src/main/java/com/example/demo/domain/cd/repository/projection/CdItemView.java
@@ -1,6 +1,6 @@
 package com.example.demo.domain.cd.repository.projection;
 
-public record CdItemView (Long cdId, Long propId,
+public record CdItemView (Long cdId, Long playlistId ,Long propId,
                           Long xCoordinate, Long yCoordinate, Long zCoordinate, Long angle,
                           String imageKey){
 }

--- a/main-server/src/main/java/com/example/demo/domain/cd/repository/projection/CdItemView.java
+++ b/main-server/src/main/java/com/example/demo/domain/cd/repository/projection/CdItemView.java
@@ -1,0 +1,6 @@
+package com.example.demo.domain.cd.repository.projection;
+
+public record CdItemView (Long cdId, Long propId,
+                          Long xCoordinate, Long yCoordinate, Long zCoordinate, Long angle,
+                          String imageKey){
+}

--- a/main-server/src/main/java/com/example/demo/domain/cd/service/CdService.java
+++ b/main-server/src/main/java/com/example/demo/domain/cd/service/CdService.java
@@ -1,0 +1,41 @@
+package com.example.demo.domain.cd.service;
+
+import com.example.demo.domain.cd.dto.response.CdItemResponse;
+import com.example.demo.domain.cd.dto.response.CdResponse;
+import com.example.demo.domain.cd.repository.CdRepository;
+import com.example.demo.domain.cd.repository.projection.CdItemView;
+import com.example.demo.global.r2.R2Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CdService {
+
+    // CdItem -> Cd -> CdList (CdItemList = Cd)
+
+    private final R2Service r2Service;
+    private final CdRepository cdRepository;
+
+    public List<CdItemResponse> findAllCdItemOnCd (Long playlistId) {
+        List<CdItemView> cdItemViewList = cdRepository.findAllWithImageKeys(playlistId);
+        return cdItemViewList.stream().map(v -> CdItemResponse.builder()
+                .cdItemId(v.cdId())
+                .propId(v.propId())
+                .xCoordinate(v.xCoordinate())
+                .yCoordinate(v.yCoordinate())
+                .zCoordinate(v.zCoordinate())
+                .angle(v.angle())
+                .imageUrl(r2Service.getPresignedUrl(v.imageKey()))
+                .build()).toList();
+    }
+
+    public CdResponse getCdByPlayListId (Long playlistId) {
+        return CdResponse.builder()
+                .playListId(playlistId)
+                .cdItems(findAllCdItemOnCd(playlistId))
+                .build();
+    }
+}

--- a/main-server/src/main/java/com/example/demo/domain/cd/service/CdService.java
+++ b/main-server/src/main/java/com/example/demo/domain/cd/service/CdService.java
@@ -1,6 +1,7 @@
 package com.example.demo.domain.cd.service;
 
 import com.example.demo.domain.cd.dto.response.CdItemResponse;
+import com.example.demo.domain.cd.dto.response.CdListResponseDto;
 import com.example.demo.domain.cd.dto.response.CdResponse;
 import com.example.demo.domain.cd.repository.CdRepository;
 import com.example.demo.domain.cd.repository.projection.CdItemView;
@@ -8,7 +9,9 @@ import com.example.demo.global.r2.R2Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -20,7 +23,7 @@ public class CdService {
     private final CdRepository cdRepository;
 
     public List<CdItemResponse> findAllCdItemOnCd (Long playlistId) {
-        List<CdItemView> cdItemViewList = cdRepository.findAllWithImageKeys(playlistId);
+        List<CdItemView> cdItemViewList = cdRepository.findAllByPlaylistWithImageKeys(playlistId);
         return cdItemViewList.stream().map(v -> CdItemResponse.builder()
                 .cdItemId(v.cdId())
                 .propId(v.propId())
@@ -32,10 +35,43 @@ public class CdService {
                 .build()).toList();
     }
 
-    public CdResponse getCdByPlayListId (Long playlistId) {
+    public CdResponse getCdByPlaylistId (Long playlistId) {
         return CdResponse.builder()
-                .playListId(playlistId)
+                .playlistId(playlistId)
                 .cdItems(findAllCdItemOnCd(playlistId))
                 .build();
+    }
+
+    public CdListResponseDto getAllCdByPlaylistIdList (List<Long> playlistIdList) {
+        if (playlistIdList == null || playlistIdList.isEmpty()) {
+            return new CdListResponseDto(List.of());
+        }
+
+        List<CdItemView> cdItemViewList = cdRepository.findAllByPlaylistIdWithImageKeysIn(playlistIdList);
+
+        var byPlaylist = cdItemViewList.stream()
+                .collect(Collectors.groupingBy(
+                        CdItemView::playlistId,
+                        LinkedHashMap::new,
+                        Collectors.mapping(r -> CdItemResponse.builder()
+                                        .cdItemId(r.cdId())
+                                        .propId(r.propId())
+                                        .xCoordinate(r.xCoordinate())
+                                        .yCoordinate(r.yCoordinate())
+                                        .zCoordinate(r.zCoordinate())
+                                        .angle(r.angle())
+                                        .imageUrl(r2Service.getPresignedUrl(r.imageKey()))
+                                        .build(),
+                                Collectors.toList()
+                        )
+                ));
+        List<CdResponse> cdResponses = byPlaylist.entrySet().stream()
+                .map(entry -> CdResponse.builder()
+                        .playlistId(entry.getKey())
+                        .cdItems(entry.getValue())
+                        .build())
+                .toList();
+
+        return new CdListResponseDto(cdResponses);
     }
 }

--- a/main-server/src/main/java/com/example/demo/domain/prop/controller/PropController.java
+++ b/main-server/src/main/java/com/example/demo/domain/prop/controller/PropController.java
@@ -73,6 +73,24 @@ public class PropController {
     }
 
     @DeleteMapping("/delete")
+    @Operation(
+            summary = "사용자의 Prop 삭제",
+            description = "사용자가 요청한 Prop (단일) 을 삭제합니다",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            content = @Content(
+                                    schema = @Schema (implementation = String.class)
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            content = @Content(
+                                    schema = @Schema (implementation = DomainException.class)
+                            )
+                    )
+            }
+    )
     public ResponseEntity<String> deleteProp(@AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestParam Long propId) {
         propService.deletePropById(customUserDetails.getId(), propId);
         return ResponseEntity.ok().body("이미지를 삭제했습니다");

--- a/main-server/src/main/java/com/example/demo/domain/prop/controller/PropController.java
+++ b/main-server/src/main/java/com/example/demo/domain/prop/controller/PropController.java
@@ -44,7 +44,7 @@ public class PropController {
     @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
         MultipartFile file = uploadPropRequestDto.file();
-        String userId = customUserDetails.getUsername();
+        String userId = customUserDetails.getId();
         propService.saveProp(userId, file);
         return ResponseEntity.ok().body("사진을 업로드하였습니다");
     }
@@ -69,9 +69,14 @@ public class PropController {
             }
     )
     public ResponseEntity<GetPropListResponseDto> getPropList(@AuthenticationPrincipal CustomUserDetails customUserDetails) { // security 적용 시 AuthenticationPrincipal 변경
-        return ResponseEntity.ok(propService.findPropListByUserId(customUserDetails.getUsername()));
+        return ResponseEntity.ok(propService.findPropListByUserId(customUserDetails.getId()));
     }
 
+    @DeleteMapping("/delete")
+    public ResponseEntity<String> deleteProp(@AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestParam Long propId) {
+        propService.deletePropById(customUserDetails.getId(), propId);
+        return ResponseEntity.ok().body("이미지를 삭제했습니다");
+    }
 
     @GetMapping("/check")
     @Operation(

--- a/main-server/src/main/java/com/example/demo/domain/prop/dto/request/UploadPropRequestDto.java
+++ b/main-server/src/main/java/com/example/demo/domain/prop/dto/request/UploadPropRequestDto.java
@@ -1,8 +1,6 @@
 package com.example.demo.domain.prop.dto.request;
 
 import com.example.demo.domain.validation.annotation.NotEmptyFile;
-import jakarta.validation.constraints.NotNull;
-import lombok.Builder;
 import org.springframework.web.multipart.MultipartFile;
 
 public record UploadPropRequestDto(@NotEmptyFile MultipartFile file) {

--- a/main-server/src/main/java/com/example/demo/domain/prop/repository/PropRepository.java
+++ b/main-server/src/main/java/com/example/demo/domain/prop/repository/PropRepository.java
@@ -4,9 +4,12 @@ import com.example.demo.domain.prop.entity.Prop;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PropRepository extends JpaRepository<Prop, Long> {
 
     List<Prop> findAllByUsers_Id(String userId);
+
+    Optional<Prop> findByIdAndUsers_Id(Long propId, String userId);
 
 }

--- a/main-server/src/main/java/com/example/demo/domain/prop/service/PropService.java
+++ b/main-server/src/main/java/com/example/demo/domain/prop/service/PropService.java
@@ -1,8 +1,9 @@
 package com.example.demo.domain.prop.service;
 
 import com.example.common.error.code.CommonErrorCode;
+import com.example.common.error.code.PropErrorCode;
 import com.example.common.error.code.UserErrorCode;
-import com.example.common.error.exception.R2Exception;
+import com.example.common.error.exception.PropException;
 import com.example.common.error.exception.UserException;
 import com.example.demo.domain.prop.dto.response.GetPropListResponseDto;
 import com.example.demo.domain.prop.dto.response.PropResponse;
@@ -37,7 +38,7 @@ public class PropService {
         try {
             r2Service.upload(file.getBytes(), file.getContentType(), imageKey); // R2에 저장
         } catch (IOException e) {
-            throw new R2Exception("R2 서버 오류입니다", CommonErrorCode.INTERNAL_ERROR);
+            throw new PropException(PropErrorCode.PROP_R2_ERROR);
         }
 
         Prop prop = Prop.builder()
@@ -59,6 +60,15 @@ public class PropService {
                 )).toList();
 
         return new GetPropListResponseDto(propResponsesList);
+    }
+
+    @Transactional
+    public void deletePropById (String userId, Long propId) {
+        Prop prop = propRepository.findByIdAndUsers_Id(propId, userId)
+                .orElseThrow(()-> new PropException(PropErrorCode.PROP_NOT_FOUND));
+
+        r2Service.delete(prop.getImageKey());
+        propRepository.delete(prop);
     }
 
     public String getPropImageUrl (String imageKey) {

--- a/main-server/src/main/java/com/example/demo/domain/prop/service/PropService.java
+++ b/main-server/src/main/java/com/example/demo/domain/prop/service/PropService.java
@@ -1,6 +1,5 @@
 package com.example.demo.domain.prop.service;
 
-import com.example.common.error.code.CommonErrorCode;
 import com.example.common.error.code.PropErrorCode;
 import com.example.common.error.code.UserErrorCode;
 import com.example.common.error.exception.PropException;

--- a/main-server/src/main/java/com/example/demo/domain/user/repository/UsersRepository.java
+++ b/main-server/src/main/java/com/example/demo/domain/user/repository/UsersRepository.java
@@ -1,10 +1,7 @@
 package com.example.demo.domain.user.repository;
 
 import com.example.demo.domain.user.entity.Users;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UsersRepository extends JpaRepository<Users, String> {
-
-    Optional<Users> findById(String username);
 }

--- a/main-server/src/main/java/com/example/demo/global/r2/R2Service.java
+++ b/main-server/src/main/java/com/example/demo/global/r2/R2Service.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
@@ -44,6 +45,15 @@ public class R2Service {
                         .contentType(contentType)
                         .build(),
                 RequestBody.fromBytes(bytes));
+    }
+
+    public void delete(String key) {
+        s3.deleteObject(
+                DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(key) // 업로드 시 사용했던 key
+                .build()
+        );
     }
 
     public String getPresignedUrl(String key) {

--- a/main-server/src/main/java/com/example/demo/global/security/config/SecurityConfig.java
+++ b/main-server/src/main/java/com/example/demo/global/security/config/SecurityConfig.java
@@ -28,6 +28,7 @@ public class SecurityConfig {
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(reg -> reg
                         .requestMatchers("/auth/login").permitAll()
+                        .requestMatchers("/auth/super").permitAll()
                         .requestMatchers("/healthz").permitAll()
                         .requestMatchers("/auth/kakao/**").permitAll()
                         .requestMatchers("/auth/session").permitAll()

--- a/main-server/src/main/java/com/example/demo/global/security/filter/CustomUserDetails.java
+++ b/main-server/src/main/java/com/example/demo/global/security/filter/CustomUserDetails.java
@@ -27,6 +27,10 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public String getUsername() {
+        return user.getUsername();
+    }
+
+    public String getId() {
         return user.getId();
     }
 

--- a/main-server/src/main/java/com/example/demo/global/security/filter/CustomUserDetailsService.java
+++ b/main-server/src/main/java/com/example/demo/global/security/filter/CustomUserDetailsService.java
@@ -1,7 +1,7 @@
 package com.example.demo.global.security.filter;
 
-import com.example.demo.domain.user.UserRepository;
 import com.example.demo.domain.user.entity.Users;
+import com.example.demo.domain.user.repository.UsersRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
 
-    private final UserRepository userRepository;
+    private final UsersRepository usersRepository;
 
     /**
      * username 파라미터를 우선 userId로 보고 조회, 없으면 email로 재조회
@@ -22,7 +22,7 @@ public class CustomUserDetailsService implements UserDetailsService {
         if (username == null || username.isBlank()) {
             throw new UsernameNotFoundException("사용자명이 비어 있습니다.");
         }
-        Users opt = userRepository.findById(username).orElseThrow(()-> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + username));
+        Users opt = usersRepository.findById(username).orElseThrow(()-> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + username));
         return new CustomUserDetails(opt);
     }
 }

--- a/main-server/src/main/java/com/example/demo/kakao/controller/LoginController.java
+++ b/main-server/src/main/java/com/example/demo/kakao/controller/LoginController.java
@@ -23,7 +23,7 @@ public class LoginController {
     private final JwtProvider jwtProvider;
     private final JwtProps jwtProps;
 
-
+    /*
     @PostMapping("/auth/login")
     public ResponseEntity<String> kakaoLogin(@Valid @RequestBody KakaoLoginRequest request) {
         KakaoLoginResponse out = authService.loginWithKakao(request.code(), request.codeVerifier());
@@ -38,4 +38,5 @@ public class LoginController {
                 .header(HttpHeaders.SET_COOKIE, cookieUtil.refreshCookie(refresh).toString())
                 .body(out.userId());
     }
+     */
 }

--- a/main-server/src/main/java/com/example/demo/kakao/controller/LoginController.java
+++ b/main-server/src/main/java/com/example/demo/kakao/controller/LoginController.java
@@ -39,4 +39,10 @@ public class LoginController {
                 .body(out.userId());
     }
      */
+
+    @GetMapping("/auth/super")
+    public ResponseEntity<String> superLogin () {
+        String superToken = jwtProvider.issueAccess("test");
+        return ResponseEntity.ok().body(superToken);
+    }
 }


### PR DESCRIPTION
Prop Delete 구현
CD Read 구현
테스트용 슈퍼계정 로그인 임시 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added CD APIs: GET /cd/{playlistId} and GET /cd/list to retrieve CDs with item coordinates (including Z) and image URLs.
  - Added DELETE /prop/delete to remove a prop by ID for the signed-in user.
  - Introduced a public test endpoint GET /auth/super to issue an access token.

- Changes
  - Kakao login flow is temporarily disabled.

- Security
  - /auth/super is accessible without authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->