### PR TITLE
Feat/chat server

### DIFF
--- a/chat-server/build.gradle
+++ b/chat-server/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 
 	// Spring Boot
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+	// developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/chat-server/src/main/java/com/example/demo/controller/ChatController.java
+++ b/chat-server/src/main/java/com/example/demo/controller/ChatController.java
@@ -1,18 +1,27 @@
 package com.example.demo.controller;
 
 
+import com.example.demo.dto.ChatHistoryResponseDto;
 import com.example.demo.dto.ChatInbound;
+import com.example.demo.dto.ChatOutbound;
 import com.example.demo.global.redis.ChatRedisCounter;
 import com.example.demo.service.ChatService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
 import java.util.Map;
 
 
@@ -30,7 +39,50 @@ public class ChatController {
     }
 
     @GetMapping("/chat/rooms/{roomId}/count")
+    @Operation(
+            summary = "채팅방 참여자 수 조회",
+            description = "해당 채팅방의 현재 참여자 수를 반환합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(example = "{\"roomId\":\"test-room\",\"count\":2}")
+                            )
+                    )
+            }
+    )
     public Map<String, Object> countLiveUser(@PathVariable String roomId) {
         return Map.of("roomId", roomId, "count", chatRedisCounter.getCount(roomId));
+    }
+
+    @GetMapping("/chat/rooms/{roomId}/history")
+    @Operation(
+            summary = "채팅방 히스토리 조회",
+            description = "요청한 채팅방의 최근 메시지를 반환합니다. 기본 50개를 반환하며, `before`가 없으면 최신부터 조회합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ChatHistoryResponseDto.class)
+                            )
+                    )
+            }
+    )
+    public ResponseEntity<ChatHistoryResponseDto> history(
+            @PathVariable String roomId,
+            @RequestParam(required = false) String before,
+            @RequestParam(defaultValue = "50") int limit
+    ) {
+        List<ChatOutbound> messages = chatService.loadRecent(roomId, before, limit);
+        String nextCursor = messages.isEmpty() ? null : messages.getLast().getSentAt();
+
+        ChatHistoryResponseDto chatHistoryResponseDto = ChatHistoryResponseDto.builder()
+                .messages(messages)
+                .nextCursor(nextCursor)
+                .build();
+
+        return ResponseEntity.ok(chatHistoryResponseDto);
     }
 }

--- a/chat-server/src/main/java/com/example/demo/dto/ChatMapper.java
+++ b/chat-server/src/main/java/com/example/demo/dto/ChatMapper.java
@@ -6,15 +6,26 @@ import java.time.Instant;
 
 public class ChatMapper {
 
-    public static Chat toEntity(ChatOutbound out) {
+    public static Chat toEntity(ChatOutbound chatOutbound) {
         String sentAt = Instant.now().toString();
         return Chat.builder()
-                .roomId(out.getRoomId())
+                .roomId(chatOutbound.getRoomId())
                 .sentAt(sentAt)
-                .messageId(out.getMessageId())
-                .senderId(out.getSenderId())
-                .content(out.getContent())
-                .systemMessage(out.isSystemMessage())
+                .messageId(chatOutbound.getMessageId())
+                .senderId(chatOutbound.getSenderId())
+                .content(chatOutbound.getContent())
+                .systemMessage(chatOutbound.isSystemMessage())
+                .build();
+    }
+
+    public static ChatOutbound toOutbound(Chat chat) {
+        return ChatOutbound.builder()
+                .roomId(chat.getRoomId())
+                .sentAt(chat.getSentAt())
+                .messageId(chat.getMessageId())
+                .senderId(chat.getSenderId())
+                .content(chat.getContent())
+                .systemMessage(chat.isSystemMessage())
                 .build();
     }
 }

--- a/chat-server/src/main/java/com/example/demo/entity/repository/ChatRepository.java
+++ b/chat-server/src/main/java/com/example/demo/entity/repository/ChatRepository.java
@@ -6,7 +6,13 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -17,8 +23,38 @@ public class ChatRepository {
     @Value("${aws.dynamodb.table}")
     private String tableName;
 
+    private DynamoDbTable<Chat> table() {
+        return enhancedClient.table(tableName, TableSchema.fromBean(Chat.class));
+    }
+
     public void save(Chat chat) {
-        DynamoDbTable<Chat> table = enhancedClient.table(tableName, TableSchema.fromBean(Chat.class));
-        table.putItem(chat);
+        table().putItem(chat);
+    }
+
+    // 최근 limit개
+    public List<Chat> queryRecent(String roomId, String before, int limit) {
+        DynamoDbTable<Chat> t = table();
+
+        QueryConditional queryConditional;
+        if (before == null) {
+            queryConditional = QueryConditional.keyEqualTo(Key.builder().partitionValue(roomId).build());
+        } else {
+            queryConditional = QueryConditional.sortLessThanOrEqualTo(
+                    Key.builder().partitionValue(roomId).sortValue(before).build()
+            );
+        }
+
+        QueryEnhancedRequest queryEnhancedRequest = QueryEnhancedRequest.builder()
+                .queryConditional(queryConditional)
+                .scanIndexForward(false) // 최신순 정렬
+                .limit(limit)
+                .build();
+
+        List<Chat> result = new ArrayList<>();
+        t.query(queryEnhancedRequest).stream()
+                .flatMap(p -> p.items().stream())
+                .forEach(result::add);
+
+        return result;
     }
 }

--- a/chat-server/src/main/java/com/example/demo/global/redis/ChatRedisSubscriber.java
+++ b/chat-server/src/main/java/com/example/demo/global/redis/ChatRedisSubscriber.java
@@ -29,7 +29,7 @@ public class ChatRedisSubscriber implements MessageListener {
             messagingTemplate.convertAndSend(destination, chatOutbound);
 
         } catch (Exception e) {
-            e.printStackTrace(); // 로깅 처리 권장
+            e.printStackTrace();
         }
     }
 }

--- a/chat-server/src/main/java/com/example/demo/global/redis/RedisConfig.java
+++ b/chat-server/src/main/java/com/example/demo/global/redis/RedisConfig.java
@@ -21,7 +21,7 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private int redisPort;
 
-    @Value("${spring.data.redis.password}")
+    @Value("${spring.data.redis.password:}")
     private String redisPassword;
 
     @Value("${spring.data.redis.ssl.enabled}")

--- a/chat-server/src/main/java/com/example/demo/service/ChatService.java
+++ b/chat-server/src/main/java/com/example/demo/service/ChatService.java
@@ -3,6 +3,7 @@ package com.example.demo.service;
 import com.example.demo.dto.ChatInbound;
 import com.example.demo.dto.ChatMapper;
 import com.example.demo.dto.ChatOutbound;
+import com.example.demo.entity.Chat;
 import com.example.demo.entity.repository.ChatRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -45,12 +47,26 @@ public class ChatService {
             throw new RuntimeException("Redis 발행 실패", e);
         }
 
-        /* 3) DynamoDB 저장
+        // 3) DynamoDB 저장
         try {
             chatRepository.save(ChatMapper.toEntity(chatOutbound));
         } catch (Exception e) {
             throw new RuntimeException("DynamoDB putItem failed", e);
         }
-        */
+    }
+
+    public List<ChatOutbound> loadRecent(String roomId, String before, int limit) {
+        int safeLimit = Math.min(Math.max(limit, 1), 50); // 1~50 제한
+        return chatRepository.queryRecent(roomId, before, safeLimit)
+                .stream()
+                .map(chat -> ChatOutbound.builder()
+                        .roomId(chat.getRoomId())
+                        .messageId(chat.getMessageId())
+                        .senderId(chat.getSenderId())
+                        .content(chat.getContent())
+                        .sentAt(chat.getSentAt())
+                        .systemMessage(chat.isSystemMessage())
+                        .build())
+                .toList();
     }
 }

--- a/main-server/src/main/java/com/example/demo/domain/prop/controller/PropController.java
+++ b/main-server/src/main/java/com/example/demo/domain/prop/controller/PropController.java
@@ -1,10 +1,8 @@
 package com.example.demo.domain.prop.controller;
 
-import com.example.common.error.exception.DomainException;
 import com.example.demo.domain.prop.dto.request.UploadPropRequestDto;
 import com.example.demo.domain.prop.dto.response.GetPropListResponseDto;
 import com.example.demo.domain.prop.service.PropService;
-import com.example.demo.domain.user.repository.UsersRepository;
 import com.example.demo.global.security.filter.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -62,9 +60,7 @@ public class PropController {
                     ),
                     @ApiResponse(
                             responseCode = "404",
-                            content = @Content(
-                                    schema = @Schema (implementation = DomainException.class)
-                            )
+                            description = "Prop 혹은 User가 없습니다"
                     )
             }
     )
@@ -85,9 +81,7 @@ public class PropController {
                     ),
                     @ApiResponse(
                             responseCode = "404",
-                            content = @Content(
-                                    schema = @Schema (implementation = DomainException.class)
-                            )
+                            description = "Prop 혹은 User가 없습니다"
                     )
             }
     )


### PR DESCRIPTION
채팅 내용 DynamoDB 저장
채팅 이력 불러오기

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added GET /chat/rooms/{roomId}/history to fetch recent messages with pagination (before, limit) and next cursor.
  - Chat messages are now persisted, enabling retrieval of room history.

- Bug Fixes
  - Redis password is now optional, preventing startup issues when not configured.

- Documentation
  - Enhanced API docs for chat history and message count.
  - Clarified 404 responses for Prop endpoints with descriptive messages.

- Chores
  - Disabled development tooling in the chat service build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->