### PR TITLE
fix: Playlist 공유 로직 수정

### DIFF
--- a/main-server/src/main/java/com/example/demo/domain/playlist/controller/PlaylistMyPageController.java
+++ b/main-server/src/main/java/com/example/demo/domain/playlist/controller/PlaylistMyPageController.java
@@ -219,7 +219,7 @@ public class PlaylistMyPageController {
                     @ExampleObject(name = "shareCode", value = "\"PL-ABCD-1234\"")
             })
     )
-    @PostMapping("/me/{playlistId}/share")
+    @PostMapping("/me/share")
     public ResponseEntity<String> sharePlaylist(
             @Parameter(hidden = true)
             @AuthenticationPrincipal CustomUserDetails user

--- a/main-server/src/main/java/com/example/demo/domain/playlist/service/PlaylistMyPageServiceImpl.java
+++ b/main-server/src/main/java/com/example/demo/domain/playlist/service/PlaylistMyPageServiceImpl.java
@@ -143,7 +143,7 @@ public class PlaylistMyPageServiceImpl implements PlaylistMyPageService {
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
         if (users.getShareCode() != null && !users.getShareCode().isBlank()) {
-            return users.getShareCode();
+            return "/shared/" + users.getShareCode();
         }
 
         String shareCode = ShareCodeGenerator.generate(userId);


### PR DESCRIPTION
불필요한 변수 제거
반환값 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified the share playlist endpoint to POST /me/share, removing the need to include a playlistId in the URL.
  - Standardized returned share links to the format /shared/{code} for both existing and newly generated share codes.
  - Existing behavior of creating or reusing a share code is unchanged; responses now always provide a full share path.
  - Note: Clients using the previous /me/{playlistId}/share path should update to the new endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->