### PR TITLE
fix: 플레이리스트 생성 트랜잭션으로 묶기

### DIFF
--- a/main-server/src/main/java/com/example/demo/domain/playlist/controller/PlaylistMyPageController.java
+++ b/main-server/src/main/java/com/example/demo/domain/playlist/controller/PlaylistMyPageController.java
@@ -41,7 +41,6 @@ public class PlaylistMyPageController {
 
     private final PlaylistMyPageService playlistMyPageService;
     private final RepresentativePlaylistService representativePlaylistService;
-    private final CdService cdService;
     private final UsersService usersService;
 
     @Operation(

--- a/main-server/src/main/java/com/example/demo/domain/playlist/controller/PlaylistMyPageController.java
+++ b/main-server/src/main/java/com/example/demo/domain/playlist/controller/PlaylistMyPageController.java
@@ -84,9 +84,7 @@ public class PlaylistMyPageController {
             throw new IllegalStateException("세션에 임시 저장된 플레이리스트가 없습니다.");
         }
 
-        PlaylistWithSongsResponse response = playlistMyPageService.savePlaylistWithSongs(user.getId(), request);
-
-        cdService.saveCdItemList(response.playlistId(), finalPlaylistRequest.saveCdRequestDto().cdItems());
+        PlaylistWithSongsResponse response = playlistMyPageService.saveFinalPlaylistWithSongsAndCd(user.getId(), request, finalPlaylistRequest.saveCdRequestDto().cdItems());
 
         session.removeAttribute("tempPlaylist");
         return ResponseEntity.ok(response);

--- a/main-server/src/main/java/com/example/demo/domain/playlist/controller/PlaylistMyPageController.java
+++ b/main-server/src/main/java/com/example/demo/domain/playlist/controller/PlaylistMyPageController.java
@@ -1,6 +1,5 @@
 package com.example.demo.domain.playlist.controller;
 
-import com.example.demo.domain.cd.service.CdService;
 import com.example.demo.domain.follow.dto.FollowPlaylistsResponse;
 import com.example.demo.domain.playlist.dto.*;
 import com.example.demo.domain.playlist.dto.playlistdto.PlaylistCreateRequest;

--- a/main-server/src/main/java/com/example/demo/domain/playlist/service/PlaylistMyPageService.java
+++ b/main-server/src/main/java/com/example/demo/domain/playlist/service/PlaylistMyPageService.java
@@ -1,5 +1,6 @@
 package com.example.demo.domain.playlist.service;
 
+import com.example.demo.domain.cd.dto.request.CdItemRequest;
 import com.example.demo.domain.follow.dto.FollowPlaylistsResponse;
 import com.example.demo.domain.playlist.dto.playlistdto.PlaylistCreateRequest;
 import com.example.demo.domain.playlist.dto.playlistdto.PlaylistDetailResponse;
@@ -9,6 +10,8 @@ import com.example.demo.domain.playlist.dto.playlistdto.PlaylistWithSongsRespons
 import java.util.List;
 
 public interface PlaylistMyPageService {
+
+    PlaylistWithSongsResponse saveFinalPlaylistWithSongsAndCd(String usersId, PlaylistCreateRequest request, List<CdItemRequest> cdItemRequestList);
 
     PlaylistWithSongsResponse savePlaylistWithSongs(String users, PlaylistCreateRequest request);
 

--- a/main-server/src/main/java/com/example/demo/domain/playlist/service/PlaylistMyPageServiceImpl.java
+++ b/main-server/src/main/java/com/example/demo/domain/playlist/service/PlaylistMyPageServiceImpl.java
@@ -4,6 +4,7 @@ import com.example.common.error.code.PlaylistErrorCode;
 import com.example.common.error.code.UserErrorCode;
 import com.example.common.error.exception.PlaylistException;
 import com.example.common.error.exception.UserException;
+import com.example.demo.domain.cd.dto.request.CdItemRequest;
 import com.example.demo.domain.cd.service.CdService;
 import com.example.demo.domain.follow.dto.FollowPlaylistDto;
 import com.example.demo.domain.follow.dto.FollowPlaylistsResponse;
@@ -91,6 +92,18 @@ public class PlaylistMyPageServiceImpl implements PlaylistMyPageService {
                 .toList();
 
         return new PlaylistWithSongsResponse(savedPlaylist.getId(), songDtos);
+    }
+
+    @Override
+    @Transactional
+    public PlaylistWithSongsResponse saveFinalPlaylistWithSongsAndCd(String usersId, PlaylistCreateRequest request,
+                                                                     List<CdItemRequest> cdItemRequestList){
+
+        PlaylistWithSongsResponse response = savePlaylistWithSongs(usersId, request);
+
+        cdService.saveCdItemList(response.playlistId(), cdItemRequestList);
+
+        return response;
     }
 
     @Override

--- a/main-server/src/main/java/com/example/demo/global/security/filter/CustomUserDetails.java
+++ b/main-server/src/main/java/com/example/demo/global/security/filter/CustomUserDetails.java
@@ -19,7 +19,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        String role = user.getRole().value(); // DB: "USER" 같은 값이라 가정
+        String role = user.getRole().value();
         if (role != null && !role.startsWith("ROLE_")) {
             role = "ROLE_" + role;
         }


### PR DESCRIPTION
기존에 컨트롤러에서 호출되어 분리된 로직을 서비스에서 트랜잭션으로 묶어서 롤백 처리 가능하도록 변경