### PR TITLE
fix(PlaylistMypageService): 대표 플레이리스트밖에 없을 때 빈 리스트 반환하는 문제 해결

### DIFF
--- a/main-server/src/main/java/com/example/demo/domain/playlist/service/PlaylistMyPageServiceImpl.java
+++ b/main-server/src/main/java/com/example/demo/domain/playlist/service/PlaylistMyPageServiceImpl.java
@@ -51,10 +51,6 @@ public class PlaylistMyPageServiceImpl implements PlaylistMyPageService {
             case RECENT -> playlistRepository.findByUserIdRecent(userId);
         };
 
-        if (all.isEmpty()) {
-            return List.of();
-        }
-
         var repOpt = representativePlaylistRepository.findByUser_Id(userId);
 
         if (repOpt.isEmpty()) {
@@ -77,7 +73,6 @@ public class PlaylistMyPageServiceImpl implements PlaylistMyPageService {
 
         return result;
     }
-
 
     @Override
     @Transactional(readOnly = true)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The representative playlist is now pinned to the top of your “My Playlists” view, followed by your other playlists.

* **Bug Fixes**
  * “My Playlists” no longer appears empty if you have a representative playlist but no other playlists match the current sort/filter; the representative playlist will still be shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->